### PR TITLE
Default colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.4.2 (Next)
 ============
 
+* [#24](https://github.com/dblock/jenkins-ansicolor-plugin/issues/24): Configurable default fg/bg colors - [@ejelly](https://github.com/ejelly).
+
 * Your contribution here.
 
 0.4.1 (12/11/2014)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -14,7 +14,7 @@ package hudson.plugins.ansicolor;
 
 class AnsiAttributeElement {
     public static enum AnsiAttrType {
-        BOLD, UNDERLINE, FG, BG
+        DEFAULT, BOLD, UNDERLINE, FG, BG
     }
 
     AnsiAttrType ansiAttrType;

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
@@ -51,6 +51,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * 
  * @author Daniel Doubrovkine
  */
+@SuppressWarnings("unused")
 public final class AnsiColorBuildWrapper extends BuildWrapper {
 
 	private final String colorMapName;
@@ -61,7 +62,7 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
 	 * Create a new {@link AnsiColorBuildWrapper}.
 	 */
 	@DataBoundConstructor
-	public AnsiColorBuildWrapper(String colorMapName) {
+	public AnsiColorBuildWrapper(String colorMapName, Integer defaultFg, Integer defaultBg) {
 		this.colorMapName = colorMapName;
 	}
 	
@@ -85,6 +86,10 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
 	@Override
 	public OutputStream decorateLogger(AbstractBuild build, final OutputStream logger) {
 		final AnsiColorMap colorMap = getDescriptor().getColorMap(getColorMapName());
+
+		if (logger == null) {
+			return null;
+		}
 
         return new LineTransformationOutputStream() {
             AnsiHtmlOutputStream ansi = new AnsiHtmlOutputStream(logger, colorMap, new AnsiAttributeElement.Emitter() {
@@ -153,6 +158,7 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
 			}
 		}
 
+		@SuppressWarnings("unused")
         public FormValidation doCheckName(@QueryParameter final String value) {
 			return (value.trim().length() == 0) ? FormValidation.error("Name cannot be empty.") : FormValidation.ok();
 		}
@@ -175,6 +181,7 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
 			return AnsiColorMap.Default;
 		}
 
+		@SuppressWarnings("unused")
 		public ListBoxModel doFillColorMapNameItems() {
 			ListBoxModel m = new ListBoxModel();
 			for(AnsiColorMap colorMap : getColorMaps()) {
@@ -183,6 +190,28 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
 					m.add(name);
 			}
 			return m;
+		}
+
+		@SuppressWarnings("unused")
+		public ListBoxModel doFillDefaultForegroundItems() {
+			ListBoxModel m = new ListBoxModel();
+
+			m.add("Jenkins Default", "");
+			m.add("black", "0");
+			m.add("red", "1");
+			m.add("green", "2");
+			m.add("yellow", "3");
+			m.add("blue", "4");
+			m.add("magenta", "5");
+			m.add("cyan", "6");
+			m.add("white", "7");
+
+			return m;
+		}
+
+		@SuppressWarnings("unused")
+		public ListBoxModel doFillDefaultBackgroundItems() {
+			return doFillDefaultForegroundItems();
 		}
 
 		/**

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorMap.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorMap.java
@@ -23,10 +23,10 @@ public final class AnsiColorMap implements Serializable
 	private static final String[] GnomeTerminalFg = { "#2E3436", "#CC0000", "#4E9A06", "#C4A000", "#3465A4", "#75507B", "#06989A", "#D3D7CF" };
 	private static final String[] GnomeTerminalBg = GnomeTerminalFg;
 
-	public static final AnsiColorMap XTerm = new AnsiColorMap(XTermName, XTermFg, XTermBg);
-	public static final AnsiColorMap VGA = new AnsiColorMap(VGAName, VGAFg, VGABg);
-	public static final AnsiColorMap CSS = new AnsiColorMap(CSSName, CSSFg, CSSBg);
-	public static final AnsiColorMap GnomeTerminal = new AnsiColorMap(GnomeTerminalName, GnomeTerminalFg, GnomeTerminalBg);
+	public static final AnsiColorMap XTerm = new AnsiColorMap(XTermName, XTermFg, XTermBg, null, null);
+	public static final AnsiColorMap VGA = new AnsiColorMap(VGAName, VGAFg, VGABg, 7, 0);
+	public static final AnsiColorMap CSS = new AnsiColorMap(CSSName, CSSFg, CSSBg, null, null);
+	public static final AnsiColorMap GnomeTerminal = new AnsiColorMap(GnomeTerminalName, GnomeTerminalFg, GnomeTerminalBg, 7, 0);
 
 	public static final AnsiColorMap Default = XTerm;
 	public static final String DefaultName = Default.getName();
@@ -40,16 +40,22 @@ public final class AnsiColorMap implements Serializable
 	private final String[] fgMap;
 	private final String[] bgMap;
 
+	// Those are nullable to not impose any default color on the output.
+	private final Integer defaultForeground;
+	private final Integer defaultBackground;
+
 	@DataBoundConstructor
 	public AnsiColorMap(
 		String name,
 		String black, String red, String green, String blue, String yellow, String magenta, String cyan, String white,
-		String blackB, String redB, String greenB, String blueB, String yellowB, String magentaB, String cyanB, String whiteB) {
+		String blackB, String redB, String greenB, String blueB, String yellowB, String magentaB, String cyanB, String whiteB,
+		Integer defaultForeground, Integer defaultBackground) {
 
 		this(
 			name,
 			colorArray(black,red,green,blue,yellow,magenta,cyan,white),
-			colorArray(blackB,redB,greenB,blueB,yellowB,magentaB,cyanB,whiteB));
+			colorArray(blackB,redB,greenB,blueB,yellowB,magentaB,cyanB,whiteB),
+			defaultForeground, defaultBackground);
 	}
 
 	private static String[] colorArray(String a, String b, String c, String d, String e, String f, String g, String h) {
@@ -57,10 +63,12 @@ public final class AnsiColorMap implements Serializable
 		return arr;
 	}
 
-	public AnsiColorMap(String name, String[] fgMap, String[] bgMap) {
+	public AnsiColorMap(String name, String[] fgMap, String[] bgMap, Integer defaultForeground, Integer defaultBackground) {
 		this.name = name;
 		this.fgMap = (String[])fgMap.clone();
 		this.bgMap = (String[])bgMap.clone();
+		this.defaultForeground = defaultForeground;
+		this.defaultBackground = defaultBackground;
 	}
 
 	public String getName() { return name; }
@@ -88,4 +96,7 @@ public final class AnsiColorMap implements Serializable
 
 	public String getForeground(int index) { return fgMap[index]; }
 	public String getBackground(int index) { return bgMap[index]; }
+
+	public Integer getDefaultForeground() { return defaultForeground; }
+	public Integer getDefaultBackground() { return defaultBackground; }
 }

--- a/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
+++ b/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
@@ -7,6 +7,12 @@
 				<f:entry title="Name" field="name">
 						<f:textbox value="${colorMap.name}"/>
 				</f:entry>
+				<f:entry title="Default Background" field="defaultBackground">
+					<f:select default="${colorMap.defaultBackground}"/>
+				</f:entry>
+				<f:entry title="Default Foreground" field="defaultForeground">
+					<f:select default="${colorMap.defaultForeground}"/>
+				</f:entry>
 				<f:entry title="Black">
 						<f:textbox title="fg" field="black" value="${colorMap.black}"/>
 						<f:textbox title="bg" field="blackB" value="${colorMap.blackB}"/>

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -157,6 +157,16 @@ public class AnsiHtmlOutputStreamTest {
     }
 
     @Test
+    public void testDefaultColors() throws IOException {
+        assertThat(
+                annotate("\033[32mtic\033[1mtac\033[39mtoe", AnsiColorMap.VGA),
+                is("<div style=\"background-color: #555555;color: #AAAAAA;\">" +
+                        "<span style=\"color: #00AA00;\">tic<b>tac</b></span><b>toe</b>" +
+                        "</div>"));
+    }
+
+
+    @Test
     public void testConsoleNote() throws IOException {
         assertThat(
             annotate(ConsoleNote.PREAMBLE_STR + "hello world" + ConsoleNote.POSTAMBLE_STR),


### PR DESCRIPTION
To close issue #24, I implemented the ability to configure a default background and foreground color. If at least one of those is set, the console output will be contained within a div with the appropriate style attribute set. Note that #24 called for setting this in the color map, but I opted for a per-job configuration instead.