### PR TITLE
AnsiColorMap: Change the serialVersionUID

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorMap.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorMap.java
@@ -8,7 +8,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class AnsiColorMap implements Serializable
 {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2950700158497010341L;
 
     public enum Color {
         BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE;


### PR DESCRIPTION
This is a fixup to commit 4ef902b that renamed member variables. The new
serialVersionUID was calculated using Java's "serialver" tool.

This is supposed to fix #57.