### PR TITLE
Support high intensity ANSI colors #16 with jansi-1.12

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,520 +1,490 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="src/main/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry including="**/*.java" kind="src" path="target/generated-sources/localizer"/>
-	<classpathentry excluding="**/*.java" including="**/*.java" kind="src" path="src/main/resources"/>
-	<classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4/mail-1.4.jar" sourcepath="M2_REPO/javax/mail/mail/1.4/mail-1.4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/javax/servlet/jstl/1.1.0/jstl-1.1.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4.jar" sourcepath="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/junit/junit/4.8.1/junit-4.8.1.jar" sourcepath="M2_REPO/junit/junit/4.8.1/junit-4.8.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar" sourcepath="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/fusesource/jansi/jansi/1.12/jansi-1.12-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/cli/1.374/cli-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10.jar" sourcepath="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/localizer/localizer/1.10/localizer-1.10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4.jar" sourcepath="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3.jar" sourcepath="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0.jar" sourcepath="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5.jar" sourcepath="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler/1.150/stapler-1.150-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar" sourcepath="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1.jar" sourcepath="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar" sourcepath="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6.jar" sourcepath="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4.jar" sourcepath="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3.jar" sourcepath="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3.jar" sourcepath="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/tiger-types/1.3/tiger-types-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/com/google/guava/guava/r06/guava-r06.jar" sourcepath="M2_REPO/com/google/guava/guava/r06/guava-r06-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/google/guava/guava/r06/guava-r06-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1.jar" sourcepath="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3.jar" sourcepath="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2.jar" sourcepath="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16.jar" sourcepath="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/args4j/args4j/2.0.16/args4j-2.0.16-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/graph-layouter/1.0/graph-layouter-1.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6.jar" sourcepath="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7.jar" sourcepath="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9.jar" sourcepath="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/jfree/jfreechart/1.0.9/jfreechart-1.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12.jar" sourcepath="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/jfree/jcommon/1.0.12/jcommon-1.0.12-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/ant/ant/1.8.1/ant-1.8.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7.jar" sourcepath="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-digester/commons-digester/1.7/commons-digester-1.7-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/jaxen/jaxen/1.1-beta-11/jaxen-1.1-beta-11.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0.jar" sourcepath="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-xml/1.1/commons-jelly-tags-xml-1.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly-tags-define/1.0.1-hudson-20071021/commons-jelly-tags-define-1.0.1-hudson-20071021.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5.jar" sourcepath="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-jdbc/1.2.9/spring-jdbc-1.2.9.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-dao/1.2.9/spring-dao-1.2.9.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar" sourcepath="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-codec/commons-codec/1.4/commons-codec-1.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/oro/oro/2.0.8/oro-2.0.8.jar" sourcepath="M2_REPO/oro/oro/2.0.8/oro-2.0.8-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9.jar" sourcepath="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0.jar" sourcepath="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/jline/jline/0.9.94/jline-0.9.94.jar" sourcepath="M2_REPO/jline/jline/0.9.94/jline-0.9.94-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" sourcepath="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1.jar" sourcepath="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624.jar" sourcepath="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14.jar" sourcepath="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/winp/winp/1.14/winp-1.14-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3.jar" sourcepath="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4.jar" sourcepath="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/com/octo/captcha/jcaptcha-all/1.0-RC6/jcaptcha-all-1.0-RC6.jar"/>
-	<classpathentry kind="var" path="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3.jar" sourcepath="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7.jar" sourcepath="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/stax/stax-api/1.0.1/stax-api-1.0.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2.jar" sourcepath="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/sun/akuma/akuma/1.2/akuma-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2.jar" sourcepath="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5.jar" sourcepath="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1.jar" sourcepath="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7.jar" sourcepath="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1.jar" sourcepath="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0.jar" sourcepath="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/asm/asm-commons/2.2.3/asm-commons-2.2.3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/asm/asm-tree/2.2.3/asm-tree-2.2.3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/asm/asm/2.2.3/asm-2.2.3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0.jar" sourcepath="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-war/1.374/hudson-war-1.374-war-for-test.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1.jar" sourcepath="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1.jar" sourcepath="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar" sourcepath="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/de/zeigermann/xml/xml-im-exporter/1.1/xml-im-exporter-1.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10.jar" sourcepath="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27.jar" sourcepath="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/jcraft/jsch/0.1.27/jsch-0.1.27-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4.jar" sourcepath="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11.jar" sourcepath="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4.jar" sourcepath="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7.jar" sourcepath="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1.jar" sourcepath="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/xalan/serializer/2.7.1/serializer-2.7.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13.jar" sourcepath="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5.jar" sourcepath="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/w3c/css/sac/1.3/sac-1.3.jar" sourcepath="M2_REPO/org/w3c/css/sac/1.3/sac-1.3-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2-sources.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/easymock/easymock/2.4/easymock-2.4.jar" sourcepath="M2_REPO/org/easymock/easymock/2.4/easymock-2.4-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/easymock/easymock/2.4/easymock-2.4-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-sources.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-javadoc.jar!/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/inject-tests">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+  <classpathentry kind="src" path="src/test/java" including="**/*.java"/>
+  <classpathentry kind="src" path="src/main/java" including="**/*.java"/>
+  <classpathentry kind="src" path="target/generated-sources/localizer" including="**/*.java"/>
+  <classpathentry kind="src" path="src/main/resources" excluding="**/*.java"/>
+  <classpathentry kind="output" path="target/eclipse-classes"/>
+  <classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4/mail-1.4.jar" sourcepath="M2_REPO/javax/mail/mail/1.4/mail-1.4-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/javax/servlet/jstl/1.1.0/jstl-1.1.0.jar"/>
+  <classpathentry kind="var" path="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4.jar" sourcepath="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4-sources.jar"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+  <classpathentry kind="var" path="M2_REPO/junit/junit/4.8.1/junit-4.8.1.jar" sourcepath="M2_REPO/junit/junit/4.8.1/junit-4.8.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar" sourcepath="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/fusesource/jansi/jansi/1.12/jansi-1.12-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/cli/1.374/cli-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10.jar" sourcepath="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/localizer/localizer/1.10/localizer-1.10-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4.jar" sourcepath="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3.jar" sourcepath="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0.jar" sourcepath="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5.jar" sourcepath="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler/1.150/stapler-1.150-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar" sourcepath="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1.jar" sourcepath="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar" sourcepath="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6.jar" sourcepath="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4.jar" sourcepath="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3.jar" sourcepath="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3.jar" sourcepath="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/tiger-types/1.3/tiger-types-1.3-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/com/google/guava/guava/r06/guava-r06.jar" sourcepath="M2_REPO/com/google/guava/guava/r06/guava-r06-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/com/google/guava/guava/r06/guava-r06-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1.jar" sourcepath="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3.jar" sourcepath="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2.jar" sourcepath="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16.jar" sourcepath="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/args4j/args4j/2.0.16/args4j-2.0.16-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/graph-layouter/1.0/graph-layouter-1.0.jar"/>
+  <classpathentry kind="var" path="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6.jar" sourcepath="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7.jar" sourcepath="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9.jar" sourcepath="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/jfree/jfreechart/1.0.9/jfreechart-1.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12.jar" sourcepath="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/jfree/jcommon/1.0.12/jcommon-1.0.12-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/ant/ant/1.8.1/ant-1.8.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7.jar" sourcepath="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-digester/commons-digester/1.7/commons-digester-1.7-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/jaxen/jaxen/1.1-beta-11/jaxen-1.1-beta-11.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0.jar" sourcepath="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-xml/1.1/commons-jelly-tags-xml-1.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly-tags-define/1.0.1-hudson-20071021/commons-jelly-tags-define-1.0.1-hudson-20071021.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5.jar" sourcepath="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-jdbc/1.2.9/spring-jdbc-1.2.9.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-dao/1.2.9/spring-dao-1.2.9.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar" sourcepath="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/commons-codec/commons-codec/1.4/commons-codec-1.4-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/oro/oro/2.0.8/oro-2.0.8.jar" sourcepath="M2_REPO/oro/oro/2.0.8/oro-2.0.8-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9.jar" sourcepath="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0.jar" sourcepath="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/jline/jline/0.9.94/jline-0.9.94.jar" sourcepath="M2_REPO/jline/jline/0.9.94/jline-0.9.94-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" sourcepath="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1.jar" sourcepath="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.jar"/>
+  <classpathentry kind="var" path="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624.jar" sourcepath="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14.jar" sourcepath="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/winp/winp/1.14/winp-1.14-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3.jar" sourcepath="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4.jar" sourcepath="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/com/octo/captcha/jcaptcha-all/1.0-RC6/jcaptcha-all-1.0-RC6.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3.jar" sourcepath="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7.jar" sourcepath="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/stax/stax-api/1.0.1/stax-api-1.0.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2.jar" sourcepath="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/com/sun/akuma/akuma/1.2/akuma-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2.jar" sourcepath="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5.jar" sourcepath="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1.jar" sourcepath="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7.jar" sourcepath="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1.jar" sourcepath="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0.jar" sourcepath="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/asm/asm-commons/2.2.3/asm-commons-2.2.3.jar"/>
+  <classpathentry kind="var" path="M2_REPO/asm/asm-tree/2.2.3/asm-tree-2.2.3.jar"/>
+  <classpathentry kind="var" path="M2_REPO/asm/asm/2.2.3/asm-2.2.3.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0.jar" sourcepath="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-war/1.374/hudson-war-1.374-war-for-test.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1.jar" sourcepath="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1.jar" sourcepath="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar" sourcepath="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/de/zeigermann/xml/xml-im-exporter/1.1/xml-im-exporter-1.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10.jar" sourcepath="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27.jar" sourcepath="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/com/jcraft/jsch/0.1.27/jsch-0.1.27-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4.jar" sourcepath="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11.jar" sourcepath="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4.jar" sourcepath="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7.jar" sourcepath="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1.jar" sourcepath="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xalan/serializer/2.7.1/serializer-2.7.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13.jar" sourcepath="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5.jar" sourcepath="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/w3c/css/sac/1.3/sac-1.3.jar" sourcepath="M2_REPO/org/w3c/css/sac/1.3/sac-1.3-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/org/easymock/easymock/2.4/easymock-2.4.jar" sourcepath="M2_REPO/org/easymock/easymock/2.4/easymock-2.4-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/easymock/easymock/2.4/easymock-2.4-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
+  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-sources.jar">
+    <attributes>
+      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-javadoc.jar!/" name="javadoc_location"/>
+    </attributes>
+  </classpathentry>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -1,490 +1,520 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="src/test/java" including="**/*.java"/>
-  <classpathentry kind="src" path="src/main/java" including="**/*.java"/>
-  <classpathentry kind="src" path="target/generated-sources/localizer" including="**/*.java"/>
-  <classpathentry kind="src" path="src/main/resources" excluding="**/*.java"/>
-  <classpathentry kind="output" path="target/eclipse-classes"/>
-  <classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4/mail-1.4.jar" sourcepath="M2_REPO/javax/mail/mail/1.4/mail-1.4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/javax/servlet/jstl/1.1.0/jstl-1.1.0.jar"/>
-  <classpathentry kind="var" path="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4.jar" sourcepath="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4-sources.jar"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-  <classpathentry kind="var" path="M2_REPO/junit/junit/4.8.1/junit-4.8.1.jar" sourcepath="M2_REPO/junit/junit/4.8.1/junit-4.8.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/fusesource/jansi/jansi/1.9/jansi-1.9.jar" sourcepath="M2_REPO/org/fusesource/jansi/jansi/1.9/jansi-1.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/fusesource/jansi/jansi/1.9/jansi-1.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/cli/1.374/cli-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10.jar" sourcepath="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/localizer/localizer/1.10/localizer-1.10-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4.jar" sourcepath="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3.jar" sourcepath="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0.jar" sourcepath="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5.jar" sourcepath="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler/1.150/stapler-1.150-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar" sourcepath="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1.jar" sourcepath="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar" sourcepath="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6.jar" sourcepath="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4.jar" sourcepath="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3.jar" sourcepath="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3.jar" sourcepath="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/tiger-types/1.3/tiger-types-1.3-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/com/google/guava/guava/r06/guava-r06.jar" sourcepath="M2_REPO/com/google/guava/guava/r06/guava-r06-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/com/google/guava/guava/r06/guava-r06-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1.jar" sourcepath="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3.jar" sourcepath="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2.jar" sourcepath="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16.jar" sourcepath="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/args4j/args4j/2.0.16/args4j-2.0.16-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/graph-layouter/1.0/graph-layouter-1.0.jar"/>
-  <classpathentry kind="var" path="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6.jar" sourcepath="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7.jar" sourcepath="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9.jar" sourcepath="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/jfree/jfreechart/1.0.9/jfreechart-1.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12.jar" sourcepath="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/jfree/jcommon/1.0.12/jcommon-1.0.12-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/ant/ant/1.8.1/ant-1.8.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7.jar" sourcepath="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-digester/commons-digester/1.7/commons-digester-1.7-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/jaxen/jaxen/1.1-beta-11/jaxen-1.1-beta-11.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0.jar" sourcepath="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-xml/1.1/commons-jelly-tags-xml-1.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly-tags-define/1.0.1-hudson-20071021/commons-jelly-tags-define-1.0.1-hudson-20071021.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5.jar" sourcepath="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-jdbc/1.2.9/spring-jdbc-1.2.9.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-dao/1.2.9/spring-dao-1.2.9.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar" sourcepath="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/commons-codec/commons-codec/1.4/commons-codec-1.4-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/oro/oro/2.0.8/oro-2.0.8.jar" sourcepath="M2_REPO/oro/oro/2.0.8/oro-2.0.8-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9.jar" sourcepath="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0.jar" sourcepath="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/jline/jline/0.9.94/jline-0.9.94.jar" sourcepath="M2_REPO/jline/jline/0.9.94/jline-0.9.94-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" sourcepath="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1.jar" sourcepath="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.jar"/>
-  <classpathentry kind="var" path="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624.jar" sourcepath="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14.jar" sourcepath="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/winp/winp/1.14/winp-1.14-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3.jar" sourcepath="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4.jar" sourcepath="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/com/octo/captcha/jcaptcha-all/1.0-RC6/jcaptcha-all-1.0-RC6.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3.jar" sourcepath="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7.jar" sourcepath="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/stax/stax-api/1.0.1/stax-api-1.0.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2.jar" sourcepath="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/com/sun/akuma/akuma/1.2/akuma-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2.jar" sourcepath="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5.jar" sourcepath="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1.jar" sourcepath="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7.jar" sourcepath="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1.jar" sourcepath="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0.jar" sourcepath="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/asm/asm-commons/2.2.3/asm-commons-2.2.3.jar"/>
-  <classpathentry kind="var" path="M2_REPO/asm/asm-tree/2.2.3/asm-tree-2.2.3.jar"/>
-  <classpathentry kind="var" path="M2_REPO/asm/asm/2.2.3/asm-2.2.3.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0.jar" sourcepath="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-war/1.374/hudson-war-1.374-war-for-test.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1.jar" sourcepath="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1.jar" sourcepath="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar" sourcepath="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/de/zeigermann/xml/xml-im-exporter/1.1/xml-im-exporter-1.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10.jar" sourcepath="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27.jar" sourcepath="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/com/jcraft/jsch/0.1.27/jsch-0.1.27-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4.jar" sourcepath="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11.jar" sourcepath="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4.jar" sourcepath="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7.jar" sourcepath="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1.jar" sourcepath="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xalan/serializer/2.7.1/serializer-2.7.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13.jar" sourcepath="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5.jar" sourcepath="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/w3c/css/sac/1.3/sac-1.3.jar" sourcepath="M2_REPO/org/w3c/css/sac/1.3/sac-1.3-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/easymock/easymock/2.4/easymock-2.4.jar" sourcepath="M2_REPO/org/easymock/easymock/2.4/easymock-2.4-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/easymock/easymock/2.4/easymock-2.4-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
-  <classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-sources.jar">
-    <attributes>
-      <attribute value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-javadoc.jar!/" name="javadoc_location"/>
-    </attributes>
-  </classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry including="**/*.java" kind="src" path="target/generated-sources/localizer"/>
+	<classpathentry excluding="**/*.java" including="**/*.java" kind="src" path="src/main/resources"/>
+	<classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4/mail-1.4.jar" sourcepath="M2_REPO/javax/mail/mail/1.4/mail-1.4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/javax/servlet/jstl/1.1.0/jstl-1.1.0.jar"/>
+	<classpathentry kind="var" path="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4.jar" sourcepath="M2_REPO/javax/servlet/servlet-api/2.4/servlet-api-2.4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/junit/junit/4.8.1/junit-4.8.1.jar" sourcepath="M2_REPO/junit/junit/4.8.1/junit-4.8.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar" sourcepath="M2_REPO/org/fusesource/jansi/jansi/1.12/jansi-1.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/fusesource/jansi/jansi/1.12/jansi-1.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-core/1.374/hudson-core-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/remoting/1.374/remoting-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/cli/1.374/cli-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/cli/1.374/cli-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10.jar" sourcepath="M2_REPO/org/jvnet/localizer/localizer/1.10/localizer-1.10-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/localizer/localizer/1.10/localizer-1.10-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/crypto-util/1.0/crypto-util-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4.jar" sourcepath="M2_REPO/commons-io/commons-io/1.4/commons-io-1.4-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/jtidy/4aug2000r7-dev-hudson-1/jtidy-4aug2000r7-dev-hudson-1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3.jar" sourcepath="M2_REPO/org/jruby/ext/posix/jna-posix/1.0.3/jna-posix-1.0.3-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0.jar" sourcepath="M2_REPO/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/trilead-putty-extension/1.0/trilead-putty-extension-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5.jar" sourcepath="M2_REPO/org/jvnet/hudson/trilead-ssh2/build212-hudson-5/trilead-ssh2-build212-hudson-5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-jelly/1.150/stapler-jelly-1.150-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler/1.150/stapler-1.150-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler/1.150/stapler-1.150-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar" sourcepath="M2_REPO/commons-discovery/commons-discovery/0.4/commons-discovery-0.4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1.jar" sourcepath="M2_REPO/commons-logging/commons-logging/1.1/commons-logging-1.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar" sourcepath="M2_REPO/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6.jar" sourcepath="M2_REPO/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/json-lib/2.1-rev6/json-lib-2.1-rev6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2/commons-collections-3.2-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4.jar" sourcepath="M2_REPO/commons-lang/commons-lang/2.4/commons-lang-2.4-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3.jar" sourcepath="M2_REPO/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/sf/ezmorph/ezmorph/1.0.3/ezmorph-1.0.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3.jar" sourcepath="M2_REPO/org/jvnet/tiger-types/1.3/tiger-types-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/tiger-types/1.3/tiger-types-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/com/google/guava/guava/r06/guava-r06.jar" sourcepath="M2_REPO/com/google/guava/guava/r06/guava-r06-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/google/guava/guava/r06/guava-r06-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1.jar" sourcepath="M2_REPO/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-fileupload/commons-fileupload/1.2.1/commons-fileupload-1.2.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/commons-jelly/1.1-hudson-20100305/commons-jelly-1.1-hudson-20100305-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508.jar" sourcepath="M2_REPO/org/jvnet/hudson/commons-jexl/1.1-hudson-20090508/commons-jexl-1.1-hudson-20090508-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3.jar" sourcepath="M2_REPO/org/jvnet/hudson/dom4j/dom4j/1.6.1-hudson-3/dom4j-1.6.1-hudson-3-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2.jar" sourcepath="M2_REPO/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/stapler/stapler-adjunct-timeline/1.2/stapler-adjunct-timeline-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2.jar" sourcepath="M2_REPO/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/infradna/tool/bridge-method-annotation/1.2/bridge-method-annotation-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/annotation-indexer/1.2/annotation-indexer-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16.jar" sourcepath="M2_REPO/args4j/args4j/2.0.16/args4j-2.0.16-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/args4j/args4j/2.0.16/args4j-2.0.16-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/task-reactor/1.2/task-reactor-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/graph-layouter/1.0/graph-layouter-1.0.jar"/>
+	<classpathentry kind="var" path="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6.jar" sourcepath="M2_REPO/antlr/antlr/2.7.6/antlr-2.7.6-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7.jar" sourcepath="M2_REPO/org/jvnet/hudson/xstream/1.3.1-hudson-7/xstream-1.3.1-hudson-7-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9.jar" sourcepath="M2_REPO/jfree/jfreechart/1.0.9/jfreechart-1.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/jfree/jfreechart/1.0.9/jfreechart-1.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12.jar" sourcepath="M2_REPO/jfree/jcommon/1.0.12/jcommon-1.0.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/jfree/jcommon/1.0.12/jcommon-1.0.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/ant/ant/1.8.1/ant-1.8.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7.jar" sourcepath="M2_REPO/commons-digester/commons-digester/1.7/commons-digester-1.7-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-digester/commons-digester/1.7/commons-digester-1.7-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/activation/1.1.1-hudson-1/activation-1.1.1-hudson-1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/jaxen/jaxen/1.1-beta-11/jaxen-1.1-beta-11.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0.jar" sourcepath="M2_REPO/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-jelly/commons-jelly-tags-xml/1.1/commons-jelly-tags-xml-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/commons-jelly-tags-define/1.0.1-hudson-20071021/commons-jelly-tags-define-1.0.1-hudson-20071021.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5.jar" sourcepath="M2_REPO/org/acegisecurity/acegi-security/1.0.5/acegi-security-1.0.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-core/2.5/spring-core-2.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-jdbc/1.2.9/spring-jdbc-1.2.9.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-beans/2.5/spring-beans-2.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-dao/1.2.9/spring-dao-1.2.9.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-context/2.5/spring-context-2.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4.jar" sourcepath="M2_REPO/commons-codec/commons-codec/1.4/commons-codec-1.4-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/commons-codec/commons-codec/1.4/commons-codec-1.4-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/oro/oro/2.0.8/oro-2.0.8.jar" sourcepath="M2_REPO/oro/oro/2.0.8/oro-2.0.8-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9.jar" sourcepath="M2_REPO/log4j/log4j/1.2.9/log4j-1.2.9-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0.jar" sourcepath="M2_REPO/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/codehaus/groovy/groovy-all/1.6.0/groovy-all-1.6.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/jline/jline/0.9.94/jline-0.9.94.jar" sourcepath="M2_REPO/jline/jline/0.9.94/jline-0.9.94-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-web/2.5/spring-web-2.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" sourcepath="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5.jar" sourcepath="M2_REPO/org/springframework/spring-aop/2.5/spring-aop-2.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar" sourcepath="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/xpp3/xpp3/1.1.4c/xpp3-1.1.4c-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1.jar" sourcepath="M2_REPO/logkit/logkit/1.0.1/logkit-1.0.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.jar"/>
+	<classpathentry kind="var" path="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624.jar" sourcepath="M2_REPO/com/sun/xml/txw2/txw2/20070624/txw2-20070624-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14.jar" sourcepath="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/winp/winp/1.14/winp-1.14-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3.jar" sourcepath="M2_REPO/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/memory-monitor/1.3/memory-monitor-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4.jar" sourcepath="M2_REPO/net/java/dev/jna/jna/3.2.4/jna-3.2.4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/com/octo/captcha/jcaptcha-all/1.0-RC6/jcaptcha-all-1.0-RC6.jar"/>
+	<classpathentry kind="var" path="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3.jar" sourcepath="M2_REPO/commons-pool/commons-pool/1.3/commons-pool-1.3-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7.jar" sourcepath="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/stax/stax-api/1.0.1/stax-api-1.0.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/jmdns/3.1.6-hudson-2/jmdns-3.1.6-hudson-2-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2.jar" sourcepath="M2_REPO/com/sun/akuma/akuma/1.2/akuma-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/sun/akuma/akuma/1.2/akuma-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2.jar" sourcepath="M2_REPO/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/libpam4j/libpam4j/1.2/libpam4j-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5.jar" sourcepath="M2_REPO/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/libzfs/libzfs/0.5/libzfs-0.5-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1.jar" sourcepath="M2_REPO/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/sun/solaris/embedded_su4j/1.1/embedded_su4j-1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7.jar" sourcepath="M2_REPO/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/java/sezpoz/sezpoz/1.7/sezpoz-1.7-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/jinterop-wmi/1.0/jinterop-wmi-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/jinterop/jinterop-proxy/1.1/jinterop-proxy-1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interop/2.0.5/j-interop-2.0.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5.jar" sourcepath="M2_REPO/org/kohsuke/jinterop/j-interopdeps/2.0.5/j-interopdeps-2.0.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1.jar" sourcepath="M2_REPO/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/samba/jcifs/jcifs/1.3.14-kohsuke-1/jcifs-1.3.14-kohsuke-1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0.jar" sourcepath="M2_REPO/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/windows-remote-command/1.0/windows-remote-command-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0.jar" sourcepath="M2_REPO/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/robust-http-client/robust-http-client/1.0/robust-http-client-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/asm/asm-commons/2.2.3/asm-commons-2.2.3.jar"/>
+	<classpathentry kind="var" path="M2_REPO/asm/asm-tree/2.2.3/asm-tree-2.2.3.jar"/>
+	<classpathentry kind="var" path="M2_REPO/asm/asm/2.2.3/asm-2.2.3.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0.jar" sourcepath="M2_REPO/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/kohsuke/access-modifier-annotation/1.0/access-modifier-annotation-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/hudson-test-harness/1.374/hudson-test-harness-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/hudson-war/1.374/hudson-war-1.374-war-for-test.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-plugin/1.374/maven-plugin-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-agent/1.374/maven-agent-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/maven-interceptor/1.374/maven-interceptor-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1.jar" sourcepath="M2_REPO/classworlds/classworlds/1.1/classworlds-1.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1.jar" sourcepath="M2_REPO/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/slide/slide-webdavlib/2.1/slide-webdavlib-2.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar" sourcepath="M2_REPO/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/de/zeigermann/xml/xml-im-exporter/1.1/xml-im-exporter-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10.jar" sourcepath="M2_REPO/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-10/doxia-sink-api-1.0-alpha-10-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar" sourcepath="M2_REPO/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar" sourcepath="M2_REPO/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.jar" sourcepath="M2_REPO/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27.jar" sourcepath="M2_REPO/com/jcraft/jsch/0.1.27/jsch-0.1.27-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/com/jcraft/jsch/0.1.27/jsch-0.1.27-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven2.1-interceptor/1.2/maven2.1-interceptor-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/maven-embedder/2.0.4-hudson-1/maven-embedder-2.0.4-hudson-1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4.jar" sourcepath="M2_REPO/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/apache/maven/maven-embedder/2.0.4/maven-embedder-2.0.4-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/wagon-webdav/1.0-beta-2-hudson-1/wagon-webdav-1.0-beta-2-hudson-1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11.jar" sourcepath="M2_REPO/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/plugins/subversion/1.11/subversion-1.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4.jar" sourcepath="M2_REPO/org/jvnet/hudson/svnkit/svnkit/1.3.0-hudson-4/svnkit-1.3.0-hudson-4-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty/6.1.11/jetty-6.1.11-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/jetty-util/6.1.11/jetty-util-6.1.11-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11.jar" sourcepath="M2_REPO/org/mortbay/jetty/servlet-api-2.5/6.1.11/servlet-api-2.5-6.1.11-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7.jar" sourcepath="M2_REPO/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/mock-javamail/mock-javamail/1.7/mock-javamail-1.7-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit/2.6-hudson-2/htmlunit-2.6-hudson-2-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1.jar" sourcepath="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/xalan/serializer/2.7.1/serializer-2.7.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1.jar" sourcepath="M2_REPO/org/jvnet/hudson/htmlunit-core-js/2.6-hudson-1/htmlunit-core-js-2.6-hudson-1-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13.jar" sourcepath="M2_REPO/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/net/sourceforge/nekohtml/nekohtml/1.9.13/nekohtml-1.9.13-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5.jar" sourcepath="M2_REPO/net/sourceforge/cssparser/cssparser/0.9.5/cssparser-0.9.5-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/w3c/css/sac/1.3/sac-1.3.jar" sourcepath="M2_REPO/org/w3c/css/sac/1.3/sac-1.3-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2.jar" sourcepath="M2_REPO/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2.jar" sourcepath="M2_REPO/org/jvnet/hudson/netx/0.5-hudson-2/netx-0.5-hudson-2-sources.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/easymock/easymock/2.4/easymock-2.4.jar" sourcepath="M2_REPO/org/easymock/easymock/2.4/easymock-2.4-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/easymock/easymock/2.4/easymock-2.4-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="var" path="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374.jar" sourcepath="M2_REPO/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/home/dblock/.m2/repository/org/jvnet/hudson/main/ui-samples-plugin/1.374/ui-samples-plugin-1.374-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/inject-tests">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>ansicolor</name>
-  <comment>Adds ANSI coloring to the Console Output. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
-  <projects/>
-  <buildSpec>
-    <buildCommand>
-      <name>org.eclipse.jdt.core.javabuilder</name>
-    </buildCommand>
-  </buildSpec>
-  <natures>
-    <nature>org.eclipse.jdt.core.javanature</nature>
-  </natures>
+	<name>ansicolor</name>
+	<comment>Adds ANSI coloring to the Console Output. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
 </projectDescription>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#72](https://github.com/dblock/jenkins-ansicolor-plugin/pull/72): Support high intensity ansi colors - [@marlene01](https://github.com/marlene01).
 * [#66](https://github.com/dblock/jenkins-ansicolor-plugin/pull/66): Improved snippet generation - [@qvicksilver](https://github.com/qvicksilver).
 
 0.4.2 (10/29/2015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
-* [#72](https://github.com/dblock/jenkins-ansicolor-plugin/pull/72): Support high intensity ansi colors - [@marlene01](https://github.com/marlene01).
+* [#72](https://github.com/dblock/jenkins-ansicolor-plugin/pull/72): Support high intensity ANSI colors - [@marlene01](https://github.com/marlene01).
 * [#66](https://github.com/dblock/jenkins-ansicolor-plugin/pull/66): Improved snippet generation - [@qvicksilver](https://github.com/qvicksilver).
 
 0.4.2 (10/29/2015)

--- a/pom.xml
+++ b/pom.xml
@@ -39,27 +39,26 @@
   <build>
     <plugins>
       <!-- Enforce Java 5.0 compatibility. -->
-      <plugin>
-        <groupId>org.jvnet</groupId>
-        <artifactId>animal-sniffer</artifactId>
-        <version>1.2</version>
-        <executions>
-          <execution>
-            <id>animal-sniffer</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <signature>
-                <groupId>org.jvnet.animal-sniffer</groupId>
-                <artifactId>java1.5</artifactId>
-                <version>1.0</version>
-              </signature>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+       <plugin>
+	    <groupId>org.codehaus.mojo</groupId>
+	    <artifactId>animal-sniffer-maven-plugin</artifactId>
+	    <configuration>
+	        <signature>
+	            <groupId>org.codehaus.mojo.signature</groupId>
+	            <artifactId>java15</artifactId>
+	            <version>1.0</version>
+	        </signature>
+	    </configuration>
+	    <executions>
+	        <execution>
+	            <id>animal-sniffer</id>
+	            <phase>verify</phase>
+	            <goals>
+	                <goal>check</goal>
+	            </goals>
+	        </execution>
+	    </executions>
+	</plugin>
       <!-- Needed to build against Jenkins/Hudson 1.387 or earlier. -->
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
@@ -89,7 +88,7 @@
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>1.9</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -24,13 +24,15 @@
 package hudson.plugins.ansicolor;
 
 import static hudson.plugins.ansicolor.AnsiAttributeElement.AnsiAttrType;
-
 import hudson.console.ConsoleNote;
+import hudson.plugins.ansicolor.AnsiAttributeElement.AnsiAttrType;
 import hudson.util.NullStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Stack;
+
 import org.fusesource.jansi.AnsiOutputStream;
 
 /**
@@ -257,6 +259,15 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         closeTagOfType(AnsiAttrType.FG); // Strictly not needed, but makes for cleaner HTML.
         openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + colorMap.getNormal(color) + ";\""));
     }
+    
+    /**
+     * Function for setting the foreground color to non standard ANSI colors (90 - 97).
+     */
+    @Override
+	protected void processSetForegroundColor(int color, boolean bright) throws IOException {
+		closeTagOfType(AnsiAttrType.BG); // Strictly not needed, but makes for cleaner HTML.
+	    openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"color: " + colorMap.getBright(color) + ";\"")); 	    
+	}
 
     @Override
     protected void processSetBackgroundColor(int color) throws IOException {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -24,15 +24,13 @@
 package hudson.plugins.ansicolor;
 
 import static hudson.plugins.ansicolor.AnsiAttributeElement.AnsiAttrType;
-import hudson.console.ConsoleNote;
-import hudson.plugins.ansicolor.AnsiAttributeElement.AnsiAttrType;
-import hudson.util.NullStream;
 
+import hudson.console.ConsoleNote;
+import hudson.util.NullStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Stack;
-
 import org.fusesource.jansi.AnsiOutputStream;
 
 /**
@@ -259,7 +257,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         closeTagOfType(AnsiAttrType.FG); // Strictly not needed, but makes for cleaner HTML.
         openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + colorMap.getNormal(color) + ";\""));
     }
-    
+
     /**
      * Function for setting the foreground color to non standard ANSI colors (90 - 97).
      */

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -264,10 +264,10 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
      * Function for setting the foreground color to non standard ANSI colors (90 - 97).
      */
     @Override
-	protected void processSetForegroundColor(int color, boolean bright) throws IOException {
-		closeTagOfType(AnsiAttrType.BG); // Strictly not needed, but makes for cleaner HTML.
-	    openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"color: " + colorMap.getBright(color) + ";\"")); 	    
-	}
+    protected void processSetForegroundColor(int color, boolean bright) throws IOException {
+         closeTagOfType(AnsiAttrType.BG); // Strictly not needed, but makes for cleaner HTML.
+         openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"color: " + colorMap.getBright(color) + ";\"")); 	    
+    }
 
     @Override
     protected void processSetBackgroundColor(int color) throws IOException {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -151,12 +151,6 @@ public class AnsiHtmlOutputStreamTest {
     }
 
     @Test
-    public void testResetBackgroundColor() throws IOException {
-        assertThatAnnotateIs("\033[42mtic\033[1mtac\033[49mtoe",
-                "<span style=\"background-color: #00CD00;\">tic<b>tac</b></span><b>toe</b>");
-    }
-
-    @Test
     public void testSetForegroundColorToHighIntensity() throws IOException {
         assertThatAnnotateIs("\033[91mLight red\033[0m",
                 "<span style=\"color: #FF0000;\">Light red</span>");
@@ -172,6 +166,12 @@ public class AnsiHtmlOutputStreamTest {
                 "<span style=\"color: #00FFFF;\">Light cyan</span>");
         assertThatAnnotateIs("\033[97mWhite\033[0m",
                 "<span style=\"color: #FFFFFF;\">White</span>");
+    }
+
+    @Test
+    public void testResetBackgroundColor() throws IOException {
+        assertThatAnnotateIs("\033[42mtic\033[1mtac\033[49mtoe",
+                "<span style=\"background-color: #00CD00;\">tic<b>tac</b></span><b>toe</b>");
     }
 
     @Test

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -157,6 +157,24 @@ public class AnsiHtmlOutputStreamTest {
     }
 
     @Test
+    public void testSetForegroundColorToHighIntensity() throws IOException {
+        assertThatAnnotateIs("\033[91mLight red\033[0m",
+                "<span style=\"color: #FF0000;\">Light red</span>");
+        assertThatAnnotateIs("\033[92mLight green\033[0m",
+                "<span style=\"color: #00FF00;\">Light green</span>");
+        assertThatAnnotateIs("\033[93mLight yellow\033[0m",
+                "<span style=\"color: #FFFF00;\">Light yellow</span>");
+        assertThatAnnotateIs("\033[94mLight blue\033[0m",
+                "<span style=\"color: #4682B4;\">Light blue</span>");
+        assertThatAnnotateIs("\033[95mLight magenta\033[0m",
+                "<span style=\"color: #FF00FF;\">Light magenta</span>");
+        assertThatAnnotateIs("\033[96mLight cyan\033[0m",
+                "<span style=\"color: #00FFFF;\">Light cyan</span>");
+        assertThatAnnotateIs("\033[97mWhite\033[0m",
+                "<span style=\"color: #FFFFFF;\">White</span>");
+    }
+
+    @Test
     public void testDefaultColors() throws IOException {
         assertThat(
                 annotate("\033[32mtic\033[1mtac\033[39mtoe", AnsiColorMap.VGA),


### PR DESCRIPTION
pom.xml changes: - increased dependency of jansi to 1.12
                 - fixed the pom error with animal-sniffer plugin
AnsiHtmlOutputStream changes:
 - added method processSetForegroundColor with additional parameter boolean bright to handle the 90 to 97 colors.