### PR TITLE
Promote pipeline configuration in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#73](https://github.com/dblock/jenkins-ansicolor-plugin/pull/73): Promote pipeline configuration in README - [@abrom](https://github.com/abrom).
 * [#72](https://github.com/dblock/jenkins-ansicolor-plugin/pull/72): Support high intensity ANSI colors - [@marlene01](https://github.com/marlene01).
 * [#66](https://github.com/dblock/jenkins-ansicolor-plugin/pull/66): Improved snippet generation - [@qvicksilver](https://github.com/qvicksilver).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ and has [a page](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) o
 
 ![enable](images/ansicolor-enable.png "Enable AnsiColor")
 
+## Using in pipeline workflows
+
+The build wrapper can be used to colorize the output of steps in a pipeline build (plugin formally known as workflows).
+The example below shows how to use it.
+
+```groovy
+wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
+  sh 'something that outputs ansi colored stuff'
+}
+```
+
 # Color!
 
 ![color](images/ansicolor.png "Color with AnsiColor")
@@ -74,16 +85,6 @@ See [issue #16](https://github.com/dblock/jenkins-ansicolor-plugin/issues/16) fo
 ## Colorizing Ruby RSpec Output
 
 RSpec formatters detect whether RSpec is running in a terminal or not, therefore suppressing color output under Jenkins. Specify `--colour --tty` when calling rspec or add it to your `.rspec` file.
-
-## Using in workflows
-
-The build wrapper can be used to colorize the output of steps in a workflow. The example below shows how to use it.
-
-```groovy
-wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
-sh 'something that outputs ansi colored stuff'
-}
-```
 
 # License
 


### PR DESCRIPTION
Documentation for configuring pipeline (workflow) builds was given 2nd class citizen status and as such it isn't entirely clear from first glance it worked

Also updated to refer to newer pipeline plugin name (as well as older workflow name)