### PR TITLE
Added support for xterm 256 colors and 24 bit colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#90](https://github.com/dblock/jenkins-ansicolor-plugin/pull/90): Added missing handling for ATTRIBUTE_CONCEAL_OFF - [@Joe-Merten](https://github.com/Joe-Merten).
 * [#90](https://github.com/dblock/jenkins-ansicolor-plugin/pull/90): Added support for italic, strikeout, framed and overline attributes - [@Joe-Merten](https://github.com/Joe-Merten).
 * [#92](https://github.com/dblock/jenkins-ansicolor-plugin/pull/92): Fixed high intensity colors for both foreground and background - [@Joe-Merten](https://github.com/Joe-Merten).
+* Added support for xterm 256 colors and 24 bit colors - [@Joe-Merten](https://github.com/Joe-Merten).
 * Your contribution here.
 
 0.4.3 (11/20/2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#90](https://github.com/dblock/jenkins-ansicolor-plugin/pull/90): Added support for italic, strikeout, framed and overline attributes - [@Joe-Merten](https://github.com/Joe-Merten).
 * [#92](https://github.com/dblock/jenkins-ansicolor-plugin/pull/92): Fixed high intensity colors for both foreground and background - [@Joe-Merten](https://github.com/Joe-Merten).
 * [#94](https://github.com/dblock/jenkins-ansicolor-plugin/pull/94): Added support for negative (inverse colors) attribute - [@Joe-Merten](https://github.com/Joe-Merten).
-* Added support for xterm 256 colors and 24 bit colors - [@Joe-Merten](https://github.com/Joe-Merten).
+* [#96](https://github.com/dblock/jenkins-ansicolor-plugin/pull/96): Added support for xterm 256 colors and 24 bit colors - [@Joe-Merten](https://github.com/Joe-Merten).
 * Your contribution here.
 
 0.4.3 (11/20/2016)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Will all print Hello in red on any system / shell that has `printf` (ie. anythin
 Most of the attributes and color modes described at [wikipedia/ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)
 were supported, including:
 
-- attributes bold / italic / underline / conceal / crossed-out / framed / overlined
+- attributes bold / italic / underline / negative / conceal / crossed-out / framed / overlined
 - standard text colors 30-37 and background colors 40-47
 - high intensity text colors 90-97 and background colors 100-107 (aixterm)
 - xterm 256 colors and ISO-8613-3 24 bit colors (38 and 48)
@@ -96,7 +96,6 @@ Not supported attributes:
 
 - faint
 - blink
-- negative
 - font switching
 - encircled
 - ideogram attributes 60-65

--- a/README.md
+++ b/README.md
@@ -82,12 +82,26 @@ For example:
 
 Will all print Hello in red on any system / shell that has `printf` (ie. anything POSIX compliant)
 
-## Supported ANSI Color Codes
+## Supported ANSI Color Codes and Attributes
 
-Only the standard [ANSI Color Codes](https://en.wikipedia.org/wiki/ANSI_colors) and "High Intensity" (aixterm)
-colors in the 90-97 / 100-107 range are supported for both foreground and background colors.
+Most of the attributes and color modes described at [wikipedia/ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)
+were supported, including:
+
+- attributes bold / italic / underline / conceal / crossed-out / framed / overlined
+- standard text colors 30-37 and background colors 40-47
+- high intensity text colors 90-97 and background colors 100-107 (aixterm)
+- xterm 256 colors and ISO-8613-3 24 bit colors (38 and 48)
+
+Not supported attributes:
+
+- faint
+- blink
+- negative
+- font switching
+- encircled
+- ideogram attributes 60-65
+
 The `colorize` ruby library, for example, emits high intensity codes when using the "light" color options.
-Extended colors (38 and 48) for 256 and 24 bit color mode are currently not supported.
 
 ## Colorizing Ruby RSpec Output
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>1.12</version>
+      <version>1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
      <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -229,8 +229,10 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
 
     @Override
     protected void processSetAttribute(int attribute) throws IOException {
-        // For some (unknown) reason, AnsiOutputStream.processEscapeCommand() sometimes(?) won't call our processSetFore/BackgroundColor().
-        // see also: https://github.com/dblock/jenkins-ansicolor-plugin/issues/91
+        //System.out.println("processSetAttribute(" + attribute + ")");
+        // For some reason, AnsiOutputStream.processEscapeCommand() sometimes won't call our processSetFore/BackgroundColor().
+        // Seems that this could be happen, if there was an old version of jansi in jenkins home directory, e.g. `/home/jenkins/.jenkins/war/WEB-INF/lib/jansi-1.9.jar`.
+        // See also: https://github.com/dblock/jenkins-ansicolor-plugin/issues/91
         if (attribute >= 90 && attribute <= 97) {
             processSetForegroundColor(attribute - 90, true);
         }
@@ -301,6 +303,73 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         }
     }
 
+    private String getRgbColor(int r, int g, int b) throws IOException {
+        if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
+            throw new IllegalArgumentException();
+        return "#" + String.format("%02X", r) + String.format("%02X", g) + String.format("%02X", b);
+    }
+
+    private String getPaletteColor(int paletteIndex) throws IOException {
+        // for xterm 256 colors see also https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
+        if (paletteIndex < 0 || paletteIndex > 255)
+            throw new IllegalArgumentException();
+
+        if (paletteIndex < 16) {
+            // xterm 256 colors seen at https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg but this source might be wrong.
+            // switch (paletteIndex) {
+            // case  0: return "#000000";
+            // case  1: return "#800000";
+            // case  2: return "#008000";
+            // case  3: return "#808000";
+            // case  4: return "#000080";
+            // case  5: return "#800080";
+            // case  6: return "#008080";
+            // case  7: return "#C0C0C0";
+            // case  8: return "#808080";
+            // case  9: return "#FF0000";
+            // case 10: return "#00FF00";
+            // case 11: return "#FFFF00";
+            // case 12: return "#0000FF";
+            // case 13: return "#FF00FF";
+            // case 14: return "#00FFFF";
+            // case 15: return "#FFFFFF";
+            // }
+            // Tested with xterm on Kubuntu 16.04 (xterm version: 322-1ubuntu1), I find out, that
+            // xterm itself uses the same 16 colors here for [30m…[37m & [90m…[97m
+            // So I decide to do it the same way.
+            if (paletteIndex < 8)
+                return colorMap.getNormal(paletteIndex);
+            else
+                return colorMap.getBright(paletteIndex - 8);
+        }
+
+        if (paletteIndex < 232) { // 216 (6*6*6) color cube
+            int c = paletteIndex - 16; // c = 0…215
+            int b = c % 6;
+            c /= 6;
+            int g = c % 6;
+            c /= 6;
+            int r = c % 6;
+            // rgb now each 0…5 - note that the translation from each 0…5 → 0…255 is not proportional, but:
+            //   0   1    2    3    4    5
+            //   0  95  135  175  215  255
+            if (r != 0) r = 55 + r * 40;
+            if (g != 0) g = 55 + g * 40;
+            if (b != 0) b = 55 + b * 40;
+            return getRgbColor(r, g, b);
+        }
+
+        if (paletteIndex < 256) { // 24 gray shades from nealy black #080808 to nearly white #EEEEEE
+            // 08, 12, 1C, 26, 30, 3A, 44, 4E, 58, 62, 6C, 76, 80, 8A, 94, 9E, A8, B2, BC, C6, D0, DA, E4, EE
+            int g = paletteIndex - 232; // c = 0…23
+            g *= 10;        // c = 0…230
+            g += 8;         // c = 8…238
+            return getRgbColor(g, g, g);
+        }
+
+        throw new IllegalArgumentException();
+    }
+
     @Override
     protected void processAttributeRest() throws IOException {
         stopConcealing();
@@ -321,6 +390,18 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     }
 
     @Override
+    protected void processSetForegroundColorExt(int paletteIndex) throws IOException {
+        closeTagOfType(AnsiAttrType.FG);
+        openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + getPaletteColor(paletteIndex) + ";\""));
+    }
+
+    @Override
+    protected void processSetForegroundColorExt(int r, int g, int b) throws IOException {
+        closeTagOfType(AnsiAttrType.FG);
+        openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + getRgbColor(r, g, b) + ";\""));
+    }
+
+    @Override
     protected void processSetBackgroundColor(int color) throws IOException {
         closeTagOfType(AnsiAttrType.BG); // Strictly not needed, but makes for cleaner HTML.
         openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + colorMap.getNormal(color) + ";\""));
@@ -332,6 +413,18 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
          closeTagOfType(AnsiAttrType.BG); // Strictly not needed, but makes for cleaner HTML.
          openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + colorMap.getBright(color) + ";\""));
     }
+
+    @Override
+    protected void processSetBackgroundColorExt(int paletteIndex) throws IOException {
+        closeTagOfType(AnsiAttrType.BG);
+        openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + getPaletteColor(paletteIndex) + ";\""));
+    }
+
+    @Override
+    protected void processSetBackgroundColorExt(int r, int g, int b) throws IOException {
+        closeTagOfType(AnsiAttrType.BG);
+        openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + getRgbColor(r, g, b) + ";\""));
+}
 
     @Override
     protected void processDefaultTextColor() throws IOException {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -556,14 +556,12 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
 
     @Override
     protected void processSetForegroundColorExt(int paletteIndex) throws IOException {
-        closeTagOfType(AnsiAttrType.FG);
-        openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + getPaletteColor(paletteIndex) + ";\""));
+        setForegroundColor(getPaletteColor(paletteIndex));
     }
 
     @Override
     protected void processSetForegroundColorExt(int r, int g, int b) throws IOException {
-        closeTagOfType(AnsiAttrType.FG);
-        openTag(new AnsiAttributeElement(AnsiAttrType.FG, "span", "style=\"color: " + getRgbColor(r, g, b) + ";\""));
+        setForegroundColor(getRgbColor(r, g, b));
     }
 
     @Override
@@ -579,15 +577,13 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
 
     @Override
     protected void processSetBackgroundColorExt(int paletteIndex) throws IOException {
-        closeTagOfType(AnsiAttrType.BG);
-        openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + getPaletteColor(paletteIndex) + ";\""));
+        setBackgroundColor(getPaletteColor(paletteIndex));
     }
 
     @Override
     protected void processSetBackgroundColorExt(int r, int g, int b) throws IOException {
-        closeTagOfType(AnsiAttrType.BG);
-        openTag(new AnsiAttributeElement(AnsiAttrType.BG, "span", "style=\"background-color: " + getRgbColor(r, g, b) + ";\""));
-}
+        setBackgroundColor(getRgbColor(r, g, b));
+    }
 
     @Override
     protected void processDefaultTextColor() throws IOException {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -171,8 +171,8 @@ public class AnsiHtmlOutputStreamTest {
     }
 
     @Test
-    public void testSetForegroundColorToHighIntensity() throws IOException {
-        assertThatAnnotateIs("\033[90mDark gray\033[0m"     , "<span style=\"color: #4C4C4C;\">Dark gray</span>");
+    public void testForegroundColorHighIntensity() throws IOException {
+        assertThatAnnotateIs("\033[90mDark gray\033[0m"    , "<span style=\"color: #4C4C4C;\">Dark gray</span>");
         assertThatAnnotateIs("\033[91mLight red\033[0m"    , "<span style=\"color: #FF0000;\">Light red</span>");
         assertThatAnnotateIs("\033[92mLight green\033[0m"  , "<span style=\"color: #00FF00;\">Light green</span>");
         assertThatAnnotateIs("\033[93mLight yellow\033[0m" , "<span style=\"color: #FFFF00;\">Light yellow</span>");
@@ -183,13 +183,84 @@ public class AnsiHtmlOutputStreamTest {
     }
 
     @Test
+    public void testForegroundColor256() throws IOException {
+        // standard colors 0-15
+        assertThatAnnotateIs("\033[38;5;0mBlack\033[0m"         , "<span style=\"color: #000000;\">Black</span>");
+        assertThatAnnotateIs("\033[38;5;1mRed\033[0m"           , "<span style=\"color: #CD0000;\">Red</span>");
+        assertThatAnnotateIs("\033[38;5;2mGreen\033[0m"         , "<span style=\"color: #00CD00;\">Green</span>");
+        assertThatAnnotateIs("\033[38;5;3mYellow\033[0m"        , "<span style=\"color: #CDCD00;\">Yellow</span>");
+        assertThatAnnotateIs("\033[38;5;4mBlue\033[0m"          , "<span style=\"color: #1E90FF;\">Blue</span>");
+        assertThatAnnotateIs("\033[38;5;5mMagenta\033[0m"       , "<span style=\"color: #CD00CD;\">Magenta</span>");
+        assertThatAnnotateIs("\033[38;5;6mCyan\033[0m"          , "<span style=\"color: #00CDCD;\">Cyan</span>");
+        assertThatAnnotateIs("\033[38;5;7mGray\033[0m"          , "<span style=\"color: #E5E5E5;\">Gray</span>");
+        assertThatAnnotateIs("\033[38;5;8mDark gray\033[0m"     , "<span style=\"color: #4C4C4C;\">Dark gray</span>");
+        assertThatAnnotateIs("\033[38;5;9mLight red\033[0m"     , "<span style=\"color: #FF0000;\">Light red</span>");
+        assertThatAnnotateIs("\033[38;5;10mLight green\033[0m"  , "<span style=\"color: #00FF00;\">Light green</span>");
+        assertThatAnnotateIs("\033[38;5;11mLight yellow\033[0m" , "<span style=\"color: #FFFF00;\">Light yellow</span>");
+        assertThatAnnotateIs("\033[38;5;12mLight blue\033[0m"   , "<span style=\"color: #4682B4;\">Light blue</span>");
+        assertThatAnnotateIs("\033[38;5;13mLight magenta\033[0m", "<span style=\"color: #FF00FF;\">Light magenta</span>");
+        assertThatAnnotateIs("\033[38;5;14mLight cyan\033[0m"   , "<span style=\"color: #00FFFF;\">Light cyan</span>");
+        assertThatAnnotateIs("\033[38;5;15mWhite\033[0m"        , "<span style=\"color: #FFFFFF;\">White</span>");
+
+        // some of the 6x6x6=216 color cube
+        assertThatAnnotateIs("\033[38;5;16mABC\033[0m"          , "<span style=\"color: #000000;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;21mABC\033[0m"          , "<span style=\"color: #0000FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;196mABC\033[0m"         , "<span style=\"color: #FF0000;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;201mABC\033[0m"         , "<span style=\"color: #FF00FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[38;5;22mABC\033[0m"          , "<span style=\"color: #005F00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;27mABC\033[0m"          , "<span style=\"color: #005FFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;202mABC\033[0m"         , "<span style=\"color: #FF5F00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;207mABC\033[0m"         , "<span style=\"color: #FF5FFF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[38;5;28mABC\033[0m"          , "<span style=\"color: #008700;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;33mABC\033[0m"          , "<span style=\"color: #0087FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;208mABC\033[0m"         , "<span style=\"color: #FF8700;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;213mABC\033[0m"         , "<span style=\"color: #FF87FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[38;5;34mABC\033[0m"          , "<span style=\"color: #00AF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;39mABC\033[0m"          , "<span style=\"color: #00AFFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;214mABC\033[0m"         , "<span style=\"color: #FFAF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;219mABC\033[0m"         , "<span style=\"color: #FFAFFF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[38;5;40mABC\033[0m"          , "<span style=\"color: #00D700;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;45mABC\033[0m"          , "<span style=\"color: #00D7FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;220mABC\033[0m"         , "<span style=\"color: #FFD700;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;225mABC\033[0m"         , "<span style=\"color: #FFD7FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[38;5;46mABC\033[0m"          , "<span style=\"color: #00FF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;51mABC\033[0m"          , "<span style=\"color: #00FFFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;226mABC\033[0m"         , "<span style=\"color: #FFFF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[38;5;231mABC\033[0m"         , "<span style=\"color: #FFFFFF;\">ABC</span>");
+
+        // some of the 24 gray shades
+        assertThatAnnotateIs("\033[38;5;232mGray\033[0m"        , "<span style=\"color: #080808;\">Gray</span>");
+        assertThatAnnotateIs("\033[38;5;240mGray\033[0m"        , "<span style=\"color: #585858;\">Gray</span>");
+        assertThatAnnotateIs("\033[38;5;248mGray\033[0m"        , "<span style=\"color: #A8A8A8;\">Gray</span>");
+        assertThatAnnotateIs("\033[38;5;255mGray\033[0m"        , "<span style=\"color: #EEEEEE;\">Gray</span>");
+    }
+
+    @Test
+    public void testForegroundColorRgb() throws IOException {
+        assertThatAnnotateIs("\033[38;2;0;0;0mBlack\033[0m"      , "<span style=\"color: #000000;\">Black</span>");
+        assertThatAnnotateIs("\033[38;2;255;0;0mRed\033[0m"      , "<span style=\"color: #FF0000;\">Red</span>");
+        assertThatAnnotateIs("\033[38;2;0;255;0mGreen\033[0m"    , "<span style=\"color: #00FF00;\">Green</span>");
+        assertThatAnnotateIs("\033[38;2;255;255;0mYellow\033[0m" , "<span style=\"color: #FFFF00;\">Yellow</span>");
+        assertThatAnnotateIs("\033[38;2;0;0;255mBlue\033[0m"     , "<span style=\"color: #0000FF;\">Blue</span>");
+        assertThatAnnotateIs("\033[38;2;255;0;255mMagenta\033[0m", "<span style=\"color: #FF00FF;\">Magenta</span>");
+        assertThatAnnotateIs("\033[38;2;0;255;255mCyan\033[0m"   , "<span style=\"color: #00FFFF;\">Cyan</span>");
+        assertThatAnnotateIs("\033[38;2;255;255;255mWhite\033[0m", "<span style=\"color: #FFFFFF;\">White</span>");
+        assertThatAnnotateIs("\033[38;2;128;128;128mGray\033[0m" , "<span style=\"color: #808080;\">Gray</span>");
+    }
+
+    @Test
     public void testResetBackgroundColor() throws IOException {
         assertThatAnnotateIs("\033[42mtic\033[1mtac\033[49mtoe",
                 "<span style=\"background-color: #00CD00;\">tic<b>tac</b></span><b>toe</b>");
     }
 
     @Test
-    public void testSetBackgroundColorToHighIntensity() throws IOException {
+    public void testBackgroundColorHighIntensity() throws IOException {
         assertThatAnnotateIs("\033[100mDark gray\033[0m"    , "<span style=\"background-color: #4C4C4C;\">Dark gray</span>");
         assertThatAnnotateIs("\033[101mLight red\033[0m"    , "<span style=\"background-color: #FF0000;\">Light red</span>");
         assertThatAnnotateIs("\033[102mLight green\033[0m"  , "<span style=\"background-color: #00FF00;\">Light green</span>");
@@ -198,6 +269,79 @@ public class AnsiHtmlOutputStreamTest {
         assertThatAnnotateIs("\033[105mLight magenta\033[0m", "<span style=\"background-color: #FF00FF;\">Light magenta</span>");
         assertThatAnnotateIs("\033[106mLight cyan\033[0m"   , "<span style=\"background-color: #00FFFF;\">Light cyan</span>");
         assertThatAnnotateIs("\033[107mWhite\033[0m"        , "<span style=\"background-color: #FFFFFF;\">White</span>");
+    }
+
+    @Test
+    public void testBackgroundColor256() throws IOException {
+        // mainly copied code from testForegroundColor256()
+        // standard colors 0-15
+        assertThatAnnotateIs("\033[48;5;0mBlack\033[0m"         , "<span style=\"background-color: #000000;\">Black</span>");
+        assertThatAnnotateIs("\033[48;5;1mRed\033[0m"           , "<span style=\"background-color: #CD0000;\">Red</span>");
+        assertThatAnnotateIs("\033[48;5;2mGreen\033[0m"         , "<span style=\"background-color: #00CD00;\">Green</span>");
+        assertThatAnnotateIs("\033[48;5;3mYellow\033[0m"        , "<span style=\"background-color: #CDCD00;\">Yellow</span>");
+        assertThatAnnotateIs("\033[48;5;4mBlue\033[0m"          , "<span style=\"background-color: #1E90FF;\">Blue</span>");
+        assertThatAnnotateIs("\033[48;5;5mMagenta\033[0m"       , "<span style=\"background-color: #CD00CD;\">Magenta</span>");
+        assertThatAnnotateIs("\033[48;5;6mCyan\033[0m"          , "<span style=\"background-color: #00CDCD;\">Cyan</span>");
+        assertThatAnnotateIs("\033[48;5;7mGray\033[0m"          , "<span style=\"background-color: #E5E5E5;\">Gray</span>");
+        assertThatAnnotateIs("\033[48;5;8mDark gray\033[0m"     , "<span style=\"background-color: #4C4C4C;\">Dark gray</span>");
+        assertThatAnnotateIs("\033[48;5;9mLight red\033[0m"     , "<span style=\"background-color: #FF0000;\">Light red</span>");
+        assertThatAnnotateIs("\033[48;5;10mLight green\033[0m"  , "<span style=\"background-color: #00FF00;\">Light green</span>");
+        assertThatAnnotateIs("\033[48;5;11mLight yellow\033[0m" , "<span style=\"background-color: #FFFF00;\">Light yellow</span>");
+        assertThatAnnotateIs("\033[48;5;12mLight blue\033[0m"   , "<span style=\"background-color: #4682B4;\">Light blue</span>");
+        assertThatAnnotateIs("\033[48;5;13mLight magenta\033[0m", "<span style=\"background-color: #FF00FF;\">Light magenta</span>");
+        assertThatAnnotateIs("\033[48;5;14mLight cyan\033[0m"   , "<span style=\"background-color: #00FFFF;\">Light cyan</span>");
+        assertThatAnnotateIs("\033[48;5;15mWhite\033[0m"        , "<span style=\"background-color: #FFFFFF;\">White</span>");
+
+        // some of the 6x6x6=216 color cube
+        assertThatAnnotateIs("\033[48;5;16mABC\033[0m"          , "<span style=\"background-color: #000000;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;21mABC\033[0m"          , "<span style=\"background-color: #0000FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;196mABC\033[0m"         , "<span style=\"background-color: #FF0000;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;201mABC\033[0m"         , "<span style=\"background-color: #FF00FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[48;5;22mABC\033[0m"          , "<span style=\"background-color: #005F00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;27mABC\033[0m"          , "<span style=\"background-color: #005FFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;202mABC\033[0m"         , "<span style=\"background-color: #FF5F00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;207mABC\033[0m"         , "<span style=\"background-color: #FF5FFF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[48;5;28mABC\033[0m"          , "<span style=\"background-color: #008700;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;33mABC\033[0m"          , "<span style=\"background-color: #0087FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;208mABC\033[0m"         , "<span style=\"background-color: #FF8700;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;213mABC\033[0m"         , "<span style=\"background-color: #FF87FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[48;5;34mABC\033[0m"          , "<span style=\"background-color: #00AF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;39mABC\033[0m"          , "<span style=\"background-color: #00AFFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;214mABC\033[0m"         , "<span style=\"background-color: #FFAF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;219mABC\033[0m"         , "<span style=\"background-color: #FFAFFF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[48;5;40mABC\033[0m"          , "<span style=\"background-color: #00D700;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;45mABC\033[0m"          , "<span style=\"background-color: #00D7FF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;220mABC\033[0m"         , "<span style=\"background-color: #FFD700;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;225mABC\033[0m"         , "<span style=\"background-color: #FFD7FF;\">ABC</span>");
+
+        assertThatAnnotateIs("\033[48;5;46mABC\033[0m"          , "<span style=\"background-color: #00FF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;51mABC\033[0m"          , "<span style=\"background-color: #00FFFF;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;226mABC\033[0m"         , "<span style=\"background-color: #FFFF00;\">ABC</span>");
+        assertThatAnnotateIs("\033[48;5;231mABC\033[0m"         , "<span style=\"background-color: #FFFFFF;\">ABC</span>");
+
+        // some of the 24 gray shades
+        assertThatAnnotateIs("\033[48;5;232mGray\033[0m"        , "<span style=\"background-color: #080808;\">Gray</span>");
+        assertThatAnnotateIs("\033[48;5;240mGray\033[0m"        , "<span style=\"background-color: #585858;\">Gray</span>");
+        assertThatAnnotateIs("\033[48;5;248mGray\033[0m"        , "<span style=\"background-color: #A8A8A8;\">Gray</span>");
+        assertThatAnnotateIs("\033[48;5;255mGray\033[0m"        , "<span style=\"background-color: #EEEEEE;\">Gray</span>");
+    }
+
+    @Test
+    public void testBackgroundColorRgb() throws IOException {
+        // mainly copied code from testForegroundColorRgb()
+        assertThatAnnotateIs("\033[48;2;0;0;0mBlack\033[0m"      , "<span style=\"background-color: #000000;\">Black</span>");
+        assertThatAnnotateIs("\033[48;2;255;0;0mRed\033[0m"      , "<span style=\"background-color: #FF0000;\">Red</span>");
+        assertThatAnnotateIs("\033[48;2;0;255;0mGreen\033[0m"    , "<span style=\"background-color: #00FF00;\">Green</span>");
+        assertThatAnnotateIs("\033[48;2;255;255;0mYellow\033[0m" , "<span style=\"background-color: #FFFF00;\">Yellow</span>");
+        assertThatAnnotateIs("\033[48;2;0;0;255mBlue\033[0m"     , "<span style=\"background-color: #0000FF;\">Blue</span>");
+        assertThatAnnotateIs("\033[48;2;255;0;255mMagenta\033[0m", "<span style=\"background-color: #FF00FF;\">Magenta</span>");
+        assertThatAnnotateIs("\033[48;2;0;255;255mCyan\033[0m"   , "<span style=\"background-color: #00FFFF;\">Cyan</span>");
+        assertThatAnnotateIs("\033[48;2;255;255;255mWhite\033[0m", "<span style=\"background-color: #FFFFFF;\">White</span>");
+        assertThatAnnotateIs("\033[48;2;128;128;128mGray\033[0m" , "<span style=\"background-color: #808080;\">Gray</span>");
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for `esc[38;…m` / `esc[48;…m` for 256 colors and 24 bit foreground / background colors. See also:
- #89
- #44
- https://issues.jenkins-ci.org/browse/JENKINS-24378

Please note, that this needs [jansi PR #72](https://github.com/fusesource/jansi/pull/72) to build & work. I'd increased the jansi version dependency in the `pom.xml` to `1.14-SNAPSHOT` to build locally.

Further, we run into a version bump as described in #95 which leads also to make 256 colors and 24 bit colors don't work (even if we have successfully build and all plugin tests passed).

As I found a way to got it work with Jenkins 1.653 (by just deleting jansi-1.9.jar), I'd found no way to make it work with Jenkins 2.x. As dblock commented in #95, we might have to wait until even the Jenkins guys will pick up the latest jansi changes.